### PR TITLE
Installation instructions for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If this fails the likely it's because the script that actually starts `lasagna` 
 Try running this command:
 
 ```
-pip3 install -e ./
+pip install -e .
 ```
 
 Then try starting Lasagna again. 

--- a/lasagna_environment.yml
+++ b/lasagna_environment.yml
@@ -1,6 +1,7 @@
 name: lasagna
 dependencies:
  - python=3
+ - pip
 # - pyqt=5
  - numpy
  - tifffile


### PR DESCRIPTION
Hi,
As discussed I went through installation steps on an old Windows laptop of mine.
Conda install gave a "SSL module not found" on an old version of conda because of missing pip dependency.
Either updating to latest conda or specifying dependency in the yaml fixed the issue.

Other issue was pip3 that is not linked at the conda prompt after activating the environment.

