### PR TITLE
Import QtWidgets to allow sparse_points pts.csv file export from add_line_plugin

### DIFF
--- a/lasagna/ingredients/sparsepoints.py
+++ b/lasagna/ingredients/sparsepoints.py
@@ -3,7 +3,7 @@ This class overlays points on top of the image stacks.
 """
 
 import numpy as np
-from PyQt5 import QtGui, QtCore
+from PyQt5 import QtGui, QtCore, QtWidgets
 from matplotlib import cm
 from numpy import linspace
 


### PR DESCRIPTION
the sparsepoints.py file does not import the QtWidgets module in PyQt5, so currently its no possible to save the sparsepoints _pts.csv.  Importing QtWidgets fixes this issue.